### PR TITLE
Implement single page scrolling layout

### DIFF
--- a/app/.gitignore
+++ b/app/.gitignore
@@ -9,6 +9,7 @@ lerna-debug.log*
 
 node_modules
 dist-ssr
+dist
 *.local
 
 # Editor directories and files

--- a/app/src/App.css
+++ b/app/src/App.css
@@ -46,8 +46,22 @@ nav ul {
   gap: 1rem;
   padding: 0;
   justify-content: center;
+  flex-wrap: wrap;
 }
 nav a {
   text-decoration: none;
   color: var(--color-primary);
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+section {
+  min-height: 100vh;
+  padding: 4rem 1rem;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
 }

--- a/app/src/App.jsx
+++ b/app/src/App.jsx
@@ -1,4 +1,3 @@
-import { BrowserRouter as Router, Routes, Route, Link } from 'react-router-dom';
 import Intro from './pages/Intro';
 import About from './pages/About';
 import Projects from './pages/Projects';
@@ -7,21 +6,27 @@ import './App.css';
 
 export default function App() {
   return (
-    <Router>
+    <>
       <nav>
         <ul>
-          <li><Link to="/">Intro</Link></li>
-          <li><Link to="/about">About</Link></li>
-          <li><Link to="/projects">Projects</Link></li>
-          <li><Link to="/blog">Blog</Link></li>
+          <li>
+            <a href="#intro">Intro</a>
+          </li>
+          <li>
+            <a href="#about">About</a>
+          </li>
+          <li>
+            <a href="#projects">Projects</a>
+          </li>
+          <li>
+            <a href="#blog">Blog</a>
+          </li>
         </ul>
       </nav>
-      <Routes>
-        <Route path="/" element={<Intro />} />
-        <Route path="/about" element={<About />} />
-        <Route path="/projects" element={<Projects />} />
-        <Route path="/blog" element={<Blog />} />
-      </Routes>
-    </Router>
+      <Intro id="intro" />
+      <About id="about" />
+      <Projects id="projects" />
+      <Blog id="blog" />
+    </>
   );
 }

--- a/app/src/pages/About.jsx
+++ b/app/src/pages/About.jsx
@@ -1,6 +1,6 @@
-export default function About() {
+export default function About({ id }) {
   return (
-    <div>
+    <section id={id}>
       <h1>About / Contact</h1>
       <p>
         Contact me at <a href="mailto:bjc9001@gmail.com">bjc9001@gmail.com</a>.
@@ -19,6 +19,6 @@ export default function About() {
           Resume (PDF)
         </a>
       </p>
-    </div>
+    </section>
   );
 }

--- a/app/src/pages/Blog.jsx
+++ b/app/src/pages/Blog.jsx
@@ -3,7 +3,7 @@ import ReactMarkdown from 'react-markdown';
 
 const posts = import.meta.glob('../posts/*.md', { as: 'raw' });
 
-export default function Blog() {
+export default function Blog({ id }) {
   const [content, setContent] = useState('');
 
   const loadPost = async (path) => {
@@ -12,7 +12,7 @@ export default function Blog() {
   };
 
   return (
-    <div>
+    <section id={id}>
       <h1>Blog</h1>
       <ul>
         {Object.keys(posts).map((path) => (
@@ -26,6 +26,6 @@ export default function Blog() {
           <ReactMarkdown>{content}</ReactMarkdown>
         </article>
       )}
-    </div>
+    </section>
   );
 }

--- a/app/src/pages/Intro.jsx
+++ b/app/src/pages/Intro.jsx
@@ -1,6 +1,6 @@
-export default function Intro() {
+export default function Intro({ id }) {
   return (
-    <section>
+    <section id={id}>
       <h1>I am Benjamin Churchill</h1>
       <p>
         I am a software engineer with 10 years experience specializing in backend

--- a/app/src/pages/Projects.jsx
+++ b/app/src/pages/Projects.jsx
@@ -13,9 +13,9 @@ const projects = [
   },
 ];
 
-export default function Projects() {
+export default function Projects({ id }) {
   return (
-    <section>
+    <section id={id}>
       <h1>Projects</h1>
       <div style={{ display: 'flex', gap: '1rem', justifyContent: 'center' }}>
         {projects.map((proj) => (


### PR DESCRIPTION
## Summary
- make landing page a single-page layout with anchors
- update each page component to accept `id` prop so navigation links scroll to sections
- add smooth scrolling and responsive styles
- ignore `dist` output in git

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685a13f0611c832195a3b762649f51df