### PR TITLE
Fix Tailwind dark mode config

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -4,6 +4,11 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <script>
+      tailwind.config = {
+        darkMode: 'class',
+      }
+    </script>
     <script src="https://cdn.tailwindcss.com"></script>
     <title>Ben Churchill</title>
   </head>

--- a/app/tailwind.config.js
+++ b/app/tailwind.config.js
@@ -1,4 +1,5 @@
-export default {
+/* global module */
+module.exports = {
   darkMode: 'class',
   content: ["./index.html", "./src/**/*.{js,jsx,ts,tsx}"],
   theme: {


### PR DESCRIPTION
## Summary
- configure Tailwind Play CDN to use `dark` class strategy
- switch Tailwind config file to CommonJS format
- declare `module` global so ESLint passes

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685a8d6036e08321aac92768e6b6565a