### PR TITLE
feat: add playful hacker theme

### DIFF
--- a/app/postcss.config.js
+++ b/app/postcss.config.js
@@ -1,9 +1,6 @@
-import tailwindcss from '@tailwindcss/postcss'
-import autoprefixer from 'autoprefixer'
+import tailwindcss from '@tailwindcss/postcss';
+import autoprefixer from 'autoprefixer';
 
 export default {
-  plugins: {
-    '@tailwindcss/postcss': {},
-    autoprefixer: {},
-  },
-}
+  plugins: [tailwindcss(), autoprefixer()],
+};

--- a/app/src/App.jsx
+++ b/app/src/App.jsx
@@ -7,32 +7,22 @@ import Contact from "./pages/Contact";
 export default function App() {
   return (
     <>
-      <nav className="sticky top-0 z-10 bg-gray-100/90 backdrop-blur py-4">
-        <ul className="flex justify-center gap-4">
+      <nav className="sticky top-0 z-10 qwex-nav py-4">
+        <ul className="flex justify-center">
           <li>
-            <a className="text-blue-600 hover:underline" href="#intro">
-              Intro
-            </a>
+            <a href="#intro">Intro</a>
           </li>
           <li>
-            <a className="text-blue-600 hover:underline" href="#about">
-              About
-            </a>
+            <a href="#about">About</a>
           </li>
           <li>
-            <a className="text-blue-600 hover:underline" href="#projects">
-              Projects
-            </a>
+            <a href="#projects">Projects</a>
           </li>
           <li>
-            <a className="text-blue-600 hover:underline" href="#blog">
-              Blog
-            </a>
+            <a href="#blog">Blog</a>
           </li>
           <li>
-            <a className="text-blue-600 hover:underline" href="#contact">
-              Contact
-            </a>
+            <a href="#contact">Contact</a>
           </li>
         </ul>
       </nav>

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -4,6 +4,145 @@
 @tailwind components;
 @tailwind utilities;
 
+:root {
+  --qwex-bg: #fbfbfe;
+  --qwex-fg: #0f172a;
+  --qwex-muted: #475569;
+  --qwex-card: #ffffff;
+  --qwex-border: #e6eaf2;
+  --qwex-header-top: #0b0f14;
+  --qwex-header-bottom: #111827;
+  --qwex-header-a: rgba(57, 255, 20, 0.12);
+  --qwex-header-b: rgba(56, 189, 248, 0.12);
+  --qwex-accent: #39ff14;
+  --qwex-accent-2: #38bdf8;
+  --qwex-link: #0ea5a0;
+  --qwex-shadow-soft: 0 12px 30px rgba(2, 6, 23, 0.08);
+  --qwex-shadow-lift: 0 16px 44px rgba(2, 6, 23, 0.12);
+  --qwex-shadow-glow: 0 0 20px rgba(57, 255, 20, 0.25);
+  --qwex-radius-lg: 20px;
+  --qwex-radius-sm: 12px;
+  --qwex-font: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Inter, Roboto,
+    "Helvetica Neue", Arial;
+  --qwex-fs-sm: 14px;
+  --qwex-fs-md: 16px;
+  --qwex-fs-lg: 18px;
+  --qwex-fs-xl: 26px;
+  --qwex-fs-xxl: 44px;
+  --qwex-space-xs: 4px;
+  --qwex-space-sm: 8px;
+  --qwex-space-md: 16px;
+  --qwex-space-lg: 24px;
+  --qwex-space-xl: 32px;
+}
+
+body {
+  background: var(--qwex-bg);
+  color: var(--qwex-fg);
+  font-family: var(--qwex-font);
+}
+
+.qwex-nav {
+  background: linear-gradient(
+    to bottom,
+    var(--qwex-header-top),
+    var(--qwex-header-bottom)
+  );
+  box-shadow: 0 2px 4px var(--qwex-border), 0 0 20px var(--qwex-header-a),
+    0 0 20px var(--qwex-header-b);
+}
+
+.qwex-nav ul {
+  gap: var(--qwex-space-md);
+}
+
+.qwex-nav a {
+  color: var(--qwex-link);
+  padding: var(--qwex-space-sm) var(--qwex-space-md);
+  border-radius: var(--qwex-radius-sm);
+  transition: box-shadow 0.2s, transform 0.2s, color 0.2s;
+}
+
+.qwex-nav a:hover {
+  color: var(--qwex-accent);
+  box-shadow: var(--qwex-shadow-glow);
+  transform: translateY(-2px);
+}
+
+.qwex-nav li:nth-child(1) a::before {
+  content: "🚀 ";
+}
+
+.qwex-nav li:nth-child(2) a::before {
+  content: "👤 ";
+}
+
+.qwex-nav li:nth-child(3) a::before {
+  content: "🛠️ ";
+}
+
+.qwex-nav li:nth-child(4) a::before {
+  content: "📚 ";
+}
+
+.qwex-nav li:nth-child(5) a::before {
+  content: "✉️ ";
+}
+
+.qwex-hero {
+  gap: var(--qwex-space-md);
+}
+
+.qwex-hero h1 {
+  font-size: var(--qwex-fs-xxl);
+  color: var(--qwex-accent);
+  text-shadow: var(--qwex-shadow-glow);
+}
+
+.qwex-hero p {
+  font-size: var(--qwex-fs-lg);
+  color: var(--qwex-muted);
+}
+
+.qwex-card {
+  background: var(--qwex-card);
+  border: 1px solid var(--qwex-border);
+  border-radius: var(--qwex-radius-lg);
+  box-shadow: var(--qwex-shadow-soft);
+  padding: var(--qwex-space-md);
+  max-width: 20rem;
+  transition: transform 0.2s, box-shadow 0.2s;
+}
+
+.qwex-card:hover {
+  box-shadow: var(--qwex-shadow-lift);
+  transform: translateY(-4px);
+}
+
+.qwex-btn {
+  background: var(--qwex-accent);
+  color: var(--qwex-fg);
+  border: 1px solid var(--qwex-border);
+  border-radius: var(--qwex-radius-sm);
+  padding: var(--qwex-space-sm) var(--qwex-space-md);
+  transition: background 0.2s, box-shadow 0.2s, transform 0.2s;
+}
+
+.qwex-btn:hover {
+  background: var(--qwex-accent-2);
+  box-shadow: var(--qwex-shadow-glow);
+  transform: translateY(-2px);
+}
+
+.qwex-link {
+  color: var(--qwex-link);
+  transition: color 0.2s;
+}
+
+.qwex-link:hover {
+  color: var(--qwex-accent-2);
+}
+
 @keyframes fade-in-up {
   from {
     opacity: 0;

--- a/app/src/pages/Blog.jsx
+++ b/app/src/pages/Blog.jsx
@@ -27,13 +27,10 @@ export default function Blog({ id }) {
       className="min-h-screen flex flex-col items-center justify-center gap-4 p-8 text-center"
     >
       <h1 className="text-4xl font-bold">Blog</h1>
-      <ul className="flex flex-col gap-2">
+      <ul className="flex flex-col gap-[var(--qwex-space-sm)]">
         {Object.keys(posts).map((path) => (
           <li key={path}>
-            <button
-              className="px-4 py-2 border rounded bg-blue-600 text-white hover:bg-blue-700"
-              onClick={() => loadPost(path)}
-            >
+            <button className="qwex-btn" onClick={() => loadPost(path)}>
               {path.split("/").pop()}
             </button>
           </li>

--- a/app/src/pages/Contact.jsx
+++ b/app/src/pages/Contact.jsx
@@ -7,7 +7,7 @@ export default function Contact({ id }) {
       <h1 className="text-4xl font-bold">Contact</h1>
       <p>
         <a
-          className="text-blue-600 inline-flex items-center gap-1"
+          className="qwex-link inline-flex items-center gap-1"
           href="mailto:bjc9001@gmail.com"
         >
           <MailIcon className="w-5 h-5" /> bjc9001@gmail.com
@@ -15,7 +15,7 @@ export default function Contact({ id }) {
       </p>
       <p>
         <a
-          className="text-blue-600 inline-flex items-center gap-1"
+          className="qwex-link inline-flex items-center gap-1"
           href="https://www.linkedin.com/in/bchurchill23/"
           target="_blank"
           rel="noopener noreferrer"
@@ -25,7 +25,7 @@ export default function Contact({ id }) {
       </p>
       <p>
         <a
-          className="text-blue-600"
+          className="qwex-link"
           href="/resume.pdf"
           target="_blank"
           rel="noopener noreferrer"

--- a/app/src/pages/Intro.jsx
+++ b/app/src/pages/Intro.jsx
@@ -2,9 +2,9 @@ export default function Intro({ id }) {
   return (
     <section
       id={id}
-      className="min-h-screen flex flex-col items-center justify-center gap-4 p-8 text-center"
+      className="min-h-screen flex flex-col items-center justify-center qwex-hero p-8 text-center"
     >
-      <h1 className="text-4xl font-bold">I am Benjamin Churchill</h1>
+      <h1 className="font-bold">I am Benjamin Churchill</h1>
       <p className="max-w-prose">Software Engineer</p>
     </section>
   );

--- a/app/src/pages/Projects.jsx
+++ b/app/src/pages/Projects.jsx
@@ -20,11 +20,11 @@ export default function Projects({ id }) {
       className="min-h-screen flex flex-col items-center justify-center gap-6 p-8 text-center"
     >
       <h1 className="text-4xl font-bold">Projects</h1>
-      <div className="flex flex-wrap justify-center gap-4">
+      <div className="flex flex-wrap justify-center gap-[var(--qwex-space-md)]">
         {projects.map((proj) => (
           <div
             key={proj.title}
-            className="border rounded shadow p-4 bg-white max-w-xs"
+            className="qwex-card"
           >
             <h2 className="text-xl font-semibold mb-2">{proj.title}</h2>
             <p>{proj.description}</p>


### PR DESCRIPTION
## Summary
- define Playful × Hacker design tokens as CSS variables
- style nav, hero, cards, and buttons using new theme
- configure postcss plugins and satisfy lint rules

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a3e9249cd08321aae993a384ee738a