### PR TITLE
Adopt terminal aesthetic and tighten layout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,150 @@
+# AGENTS
+
+This file guides agentic contributors in this repo.
+
+## Repository layout
+- `app/` Vite + React + Tailwind source.
+- `.github/workflows/` CI and deploy workflows.
+- `CNAME` GitHub Pages custom domain.
+
+## Working directory
+- Run all node commands from `app/`.
+- Node version in CI: 20.
+
+## Install
+- `cd app`
+- `npm install`
+
+## Dev server
+- `npm run dev`
+- Default Vite host/port.
+
+## Build
+- `npm run build`
+- Output in `app/dist/`.
+
+## Preview production build
+- `npm run preview`
+
+## Lint
+- `npm run lint`
+- Uses `app/eslint.config.js`.
+
+## Tests
+- No test runner is configured.
+- There is no `npm test` script.
+- Single test execution: not applicable.
+- If you add tests, document the new command here.
+
+## CI / CD
+- CI runs in `.github/workflows/ci.yml`.
+- Steps: `npm ci`, `npm run lint`, `npm run build`.
+- Deploy workflow builds and publishes `app/dist`.
+
+## Code style overview
+- React 19 with JSX, function components, and hooks.
+- JavaScript only (no TypeScript).
+- PropTypes are used for public component props.
+- Prefer small, focused components with clear props.
+- Keep UI state in component state; lift only when needed.
+- Tailwind utility classes are the primary styling method.
+
+## Imports
+- Group imports: external packages first, then local modules.
+- Use relative imports within `app/src`.
+- Use default exports for components.
+- Keep `import` order stable within a file.
+
+## Formatting
+- Indentation: 2 spaces.
+- Most `app/src` files use double quotes and semicolons.
+- Some tooling files use single quotes and no semicolons.
+- Match existing style in the file you edit.
+- Keep JSX props aligned and readable.
+
+## Naming
+- Component files use PascalCase: `Card.jsx`.
+- Component functions use PascalCase.
+- Local variables use camelCase.
+- Constants use `const` and uppercase only for invariants.
+
+## Types and props
+- Use PropTypes at the bottom of the file.
+- Mark required props with `isRequired`.
+- Prefer simple primitive prop types when possible.
+
+## Error handling
+- Use `try/catch` around async UI flows.
+- Provide a user-visible fallback message on failure.
+- Avoid throwing in render paths.
+
+## State and effects
+- Keep effect dependencies accurate and minimal.
+- Clean up event listeners and side effects.
+- Avoid unnecessary global DOM changes.
+
+## Styling and CSS
+- Tailwind classes live in `className` strings.
+- Prefer existing CSS variables in `app/src/index.css`.
+- Avoid inline styles unless required for dynamic values.
+- Animations are handled via classes in CSS.
+
+## Content and data
+- Static content lives in component files.
+- Blog posts are Markdown in `app/src/posts/`.
+- `import.meta.glob` is used to load posts.
+
+## Accessibility
+- Include `aria-*` when needed for interactive elements.
+- Buttons and links should be keyboard-accessible.
+- Use `rel="noopener noreferrer"` for new tabs.
+
+## Deployment notes
+- GitHub Pages uses `CNAME` and `app/dist`.
+- Vite base is `/` for the custom domain.
+
+## Cursor / Copilot rules
+- No `.cursor/rules`, `.cursorrules`, or Copilot instructions found.
+- If new rules are added, mirror them here.
+
+## Agent workflow
+- Read `README.md` and `app/package.json` first.
+- Prefer edits that keep the UI consistent with existing sections.
+- Avoid introducing new frameworks or build tools.
+- Keep changes scoped to `app/` unless instructed.
+
+## Suggested quick checks
+- Run `npm run lint` after code edits.
+- Run `npm run build` before deploying.
+
+## File references
+- Entry: `app/src/main.jsx`.
+- App shell: `app/src/App.jsx`.
+- Pages: `app/src/pages/*`.
+- Shared components: `app/src/components/*`.
+- Global styles: `app/src/index.css`.
+
+## Known gaps
+- No automated tests.
+- No formatter configured (Prettier not present).
+
+## When adding new files
+- Use `.jsx` for React components.
+- Export a default component.
+- Add PropTypes if the component accepts props.
+- Keep file location consistent with current structure.
+
+## When editing existing files
+- Preserve the component API unless asked to change it.
+- Keep class names consistent with existing naming.
+- Follow the same quote and semicolon style in the file.
+
+## Misc
+- `npm run deploy` uses `gh-pages` and expects `app/dist`.
+- `npm run predeploy` runs `npm run build`.
+
+## Contact
+- Project owner: Benjamin Churchill.
+- Website: https://qwex.co
+
+## End

--- a/TERMINAL_AESTHETIC.md
+++ b/TERMINAL_AESTHETIC.md
@@ -1,0 +1,52 @@
+# Terminal Aesthetic Direction
+
+## Core idea
+Compact, old‑web, monospace terminal vibe: dense layout, minimal padding, high contrast, and a restrained palette that feels like a CRT or text console. The site reads like a well-structured terminal session rather than a modern hero-scroll page.
+
+## Visual language
+- Typography: one primary monospace family with strong personality; use regular and bold weights for hierarchy, keep sizes tight.
+- Palette: charcoal/near-black background with muted phosphor green for primary, amber for secondary highlights, and soft gray for body text.
+- Layout: tighter vertical rhythm, reduced section spacing, content stacked in bordered blocks that feel like terminal panes.
+- Surfaces: subtle scanline or noise texture, hairline borders, and faint glow for interactive elements.
+- Motion: minimal; use quick cursor blink and subtle focus outlines, avoid large scroll-reveal animations.
+
+## Structure changes
+- Replace large hero blocks with a compact “prompt” style intro.
+- Convert sections into terminal “cards” with headers that look like command output (e.g., `> projects`).
+- Move nav into a slim top bar that looks like a status line.
+- Reduce max widths and margins; align to a consistent grid with narrow gutters.
+
+## Component styling ideas
+- Buttons: look like terminal commands (outlined, monospace, uppercase, `>` prefix).
+- Links: underline with dotted/terminal-style, highlight on hover with invert.
+- Cards: bordered rectangles with subtle inset shadow and a small title bar.
+- Icons/emoji: keep, but render smaller and align to text baseline.
+
+## UX details
+- Show a blinking cursor in the intro and maybe in section headers.
+- Keep interactions keyboard-friendly; focus rings should be bright and visible.
+- Use concise copy and avoid excessive whitespace.
+
+## Responsive behavior
+- Mobile first: single-column, narrow paddings, and compact line heights.
+- Desktop: keep density but allow wider panes; avoid huge vertical gaps.
+- Nav: condensed status bar on mobile; expand to full inline menu on desktop.
+- Cards: full-width on mobile, two-column grid only where it reads cleanly.
+- Touch targets: keep 44px minimum height without inflating overall spacing.
+
+## CSS primitives to introduce
+- CSS variables for colors: `--terminal-bg`, `--terminal-fg`, `--terminal-accent`, `--terminal-muted`.
+- Global font family set to the monospace font with fallbacks.
+- Utility classes for `terminal-pane`, `terminal-title`, `terminal-prompt`.
+
+## What stays the same
+- Existing content, sections, and navigation structure.
+- React component structure; changes are styling + light layout tweaks.
+
+## Libraries
+- No new libraries required. Tailwind + existing CSS are sufficient to reach the terminal look and responsive goals.
+- If we choose a custom monospace font, we can load it via standard webfont link or a local asset, no framework change.
+
+## Open questions for you
+- Preferred monospace font: classic (e.g., IBM Plex Mono) or retro (e.g., VT323)?
+- Accent color: phosphor green only, or green + amber highlights?

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -11,7 +11,8 @@
         "prop-types": "^15.8.1",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
-        "react-markdown": "^10.1.0"
+        "react-markdown": "^10.1.0",
+        "remark-gfm": "^4.0.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.25.0",
@@ -3515,6 +3516,44 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/mdast-util-from-markdown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.2.tgz",
@@ -3533,6 +3572,107 @@
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0",
         "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -3745,6 +3885,127 @@
         "micromark-util-subtokenize": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/micromark-factory-destination": {
@@ -4636,6 +4897,24 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/remark-parse": {
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
@@ -4663,6 +4942,21 @@
         "mdast-util-to-hast": "^13.0.0",
         "unified": "^11.0.0",
         "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -5308,21 +5602,6 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/yaml": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
-      "integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/app/package.json
+++ b/app/package.json
@@ -15,7 +15,8 @@
     "prop-types": "^15.8.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "react-markdown": "^10.1.0"
+    "react-markdown": "^10.1.0",
+    "remark-gfm": "^4.0.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/app/src/App.jsx
+++ b/app/src/App.jsx
@@ -6,11 +6,11 @@ import Blog from "./pages/Blog";
 import Contact from "./pages/Contact";
 
 const navItems = [
-  { href: "#intro", label: "Intro", emoji: "🚀" },
-  { href: "#projects", label: "Projects", emoji: "🛠️" },
-  { href: "#blog", label: "Blog", emoji: "📚" },
-  { href: "#about", label: "About", emoji: "👤" },
-  { href: "#contact", label: "Contact", emoji: "✉️" },
+  { href: "#intro", label: "Intro" },
+  { href: "#projects", label: "Projects" },
+  { href: "#blog", label: "Blog" },
+  { href: "#about", label: "About" },
+  { href: "#contact", label: "Contact" },
 ];
 
 export default function App() {
@@ -43,12 +43,12 @@ export default function App() {
 
   return (
     <>
-      <nav className="sticky top-0 z-50 qwex-nav py-3 md:py-4 px-4">
+      <nav className="sticky top-0 z-50 qwex-nav py-2 md:py-2 px-3">
         {/* Desktop Navigation */}
         <ul className="hidden md:flex justify-center">
           {navItems.map((item) => (
             <li key={item.href}>
-              <a href={item.href} data-emoji={item.emoji}>
+              <a href={item.href}>
                 {item.label}
               </a>
             </li>
@@ -59,7 +59,7 @@ export default function App() {
         <div className="md:hidden flex items-center justify-between">
           <a
             href="#intro"
-            className="text-[var(--qwex-accent)] font-bold text-lg"
+            className="text-[var(--qwex-accent)] font-bold text-base"
             onClick={handleNavClick}
           >
             BC

--- a/app/src/components/Card.jsx
+++ b/app/src/components/Card.jsx
@@ -5,7 +5,7 @@ export default function Card({ children, className = "", contentClassName = "", 
     <div className={`qwex-card group relative overflow-hidden ${className}`} style={style}>
       <div className="absolute inset-0 bg-gradient-to-r from-[var(--qwex-accent)] to-[var(--qwex-accent-2)] opacity-0 group-hover:opacity-10 transition-opacity duration-300" />
 
-      <div className={`relative z-10 p-4 sm:p-6 ${contentClassName}`}>
+      <div className={`relative z-10 p-3 sm:p-4 ${contentClassName}`}>
         {children}
       </div>
     </div>

--- a/app/src/components/Card.jsx
+++ b/app/src/components/Card.jsx
@@ -3,8 +3,7 @@ import PropTypes from "prop-types";
 export default function Card({ children, className = "", contentClassName = "", style }) {
   return (
     <div className={`qwex-card group relative overflow-hidden ${className}`} style={style}>
-      {/* Hacker-style accent border */}
-      <div className="absolute inset-0 bg-gradient-to-r from-[var(--qwex-accent)] to-[var(--qwex-accent-2)] opacity-0 group-hover:opacity-20 transition-opacity duration-300" />
+      <div className="absolute inset-0 bg-gradient-to-r from-[var(--qwex-accent)] to-[var(--qwex-accent-2)] opacity-0 group-hover:opacity-10 transition-opacity duration-300" />
 
       <div className={`relative z-10 p-4 sm:p-6 ${contentClassName}`}>
         {children}

--- a/app/src/components/Section.jsx
+++ b/app/src/components/Section.jsx
@@ -4,7 +4,7 @@ export default function Section({ id, children, className = "" }) {
   return (
     <section
       id={id}
-      className={`min-h-screen flex flex-col items-center justify-center gap-6 sm:gap-8 px-4 py-12 sm:p-8 text-center animate-fade-in-up ${className}`}
+      className={`flex flex-col items-center justify-start gap-4 sm:gap-5 px-4 py-6 sm:py-8 text-center animate-fade-in-up ${className}`}
     >
       {children}
     </section>

--- a/app/src/components/SectionHeader.jsx
+++ b/app/src/components/SectionHeader.jsx
@@ -1,18 +1,19 @@
 import PropTypes from "prop-types";
 
-export default function SectionHeader({ emoji, title, subtitle }) {
+export default function SectionHeader({ title, subtitle }) {
   return (
     <div className="qwex-hero">
-      <h1 className="qwex-title text-2xl sm:text-3xl md:text-4xl font-semibold">
-        {emoji} {title}
+      <h1 className="qwex-title text-lg sm:text-xl md:text-2xl font-semibold">
+        {title}
       </h1>
-      <p className="text-base sm:text-lg opacity-80 mt-2">{subtitle}</p>
+      {subtitle && (
+        <p className="text-sm sm:text-base opacity-80 mt-1">{subtitle}</p>
+      )}
     </div>
   );
 }
 
 SectionHeader.propTypes = {
-  emoji: PropTypes.string.isRequired,
   title: PropTypes.string.isRequired,
-  subtitle: PropTypes.string.isRequired,
+  subtitle: PropTypes.string,
 };

--- a/app/src/components/SectionHeader.jsx
+++ b/app/src/components/SectionHeader.jsx
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 export default function SectionHeader({ emoji, title, subtitle }) {
   return (
     <div className="qwex-hero">
-      <h1 className="text-2xl sm:text-3xl md:text-4xl font-bold">
+      <h1 className="qwex-title text-2xl sm:text-3xl md:text-4xl font-semibold">
         {emoji} {title}
       </h1>
       <p className="text-base sm:text-lg opacity-80 mt-2">{subtitle}</p>

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -1,25 +1,28 @@
 @import "tailwindcss";
+@import url("https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Work+Sans:wght@400;500;600&display=swap");
 
 :root {
-  --qwex-bg: #0f1419;
-  --qwex-fg: #e6edf3;
-  --qwex-muted: #8b949e;
-  --qwex-card: #161b22;
-  --qwex-border: #30363d;
-  --qwex-header-top: #0b0f14;
-  --qwex-header-bottom: #111827;
-  --qwex-header-a: rgba(57, 255, 20, 0.12);
-  --qwex-header-b: rgba(56, 189, 248, 0.12);
-  --qwex-accent: #39ff14;
-  --qwex-accent-2: #38bdf8;
-  --qwex-link: #58a6ff;
-  --qwex-shadow-soft: 0 12px 30px rgba(0, 0, 0, 0.3);
-  --qwex-shadow-lift: 0 16px 44px rgba(0, 0, 0, 0.4);
-  --qwex-shadow-glow: 0 0 20px rgba(57, 255, 20, 0.4);
+  --qwex-bg: #0c1116;
+  --qwex-fg: #e7edf4;
+  --qwex-muted: #9aa6b2;
+  --qwex-card: #141a21;
+  --qwex-border: #22303a;
+  --qwex-header-top: #0a0f14;
+  --qwex-header-bottom: #111821;
+  --qwex-header-a: rgba(125, 211, 252, 0.12);
+  --qwex-header-b: rgba(167, 243, 208, 0.12);
+  --qwex-accent: #7dd3fc;
+  --qwex-accent-2: #a7f3d0;
+  --qwex-link: #8ab4f8;
+  --qwex-shadow-soft: 0 10px 26px rgba(0, 0, 0, 0.28);
+  --qwex-shadow-lift: 0 16px 36px rgba(0, 0, 0, 0.38);
+  --qwex-shadow-glow: 0 0 16px rgba(125, 211, 252, 0.25);
   --qwex-radius-lg: 20px;
   --qwex-radius-sm: 12px;
-  --qwex-font: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Inter,
-    Roboto, "Helvetica Neue", Arial;
+  --qwex-font-body: "Work Sans", ui-sans-serif, system-ui, -apple-system,
+    "Segoe UI", "Helvetica Neue", Arial;
+  --qwex-font-display: "Space Grotesk", "Work Sans", ui-sans-serif, system-ui,
+    -apple-system, "Segoe UI", "Helvetica Neue", Arial;
   --qwex-fs-sm: 14px;
   --qwex-fs-md: 16px;
   --qwex-fs-lg: 18px;
@@ -54,9 +57,20 @@ html {
 /* Base body styles */
 body {
   overflow-x: hidden;
-  background: var(--qwex-bg);
+  background: radial-gradient(
+      1200px 800px at 12% -10%,
+      rgba(125, 211, 252, 0.14),
+      transparent 55%
+    ),
+    radial-gradient(
+      900px 650px at 88% 10%,
+      rgba(167, 243, 208, 0.12),
+      transparent 55%
+    ),
+    var(--qwex-bg);
+  background-attachment: fixed;
   color: var(--qwex-fg);
-  font-family: var(--qwex-font);
+  font-family: var(--qwex-font-body);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
@@ -67,8 +81,7 @@ body {
     var(--qwex-header-top),
     var(--qwex-header-bottom)
   );
-  box-shadow: 0 2px 4px var(--qwex-border), 0 0 20px var(--qwex-header-a),
-    0 0 20px var(--qwex-header-b);
+  box-shadow: 0 1px 0 var(--qwex-border), 0 12px 30px rgba(0, 0, 0, 0.25);
 }
 
 .qwex-nav ul {
@@ -79,13 +92,15 @@ body {
   color: var(--qwex-link);
   padding: var(--qwex-space-sm) var(--qwex-space-md);
   border-radius: var(--qwex-radius-sm);
-  transition: box-shadow 0.2s, transform 0.2s, color 0.2s;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+  transition: background 0.2s, transform 0.2s, color 0.2s;
 }
 
 .qwex-nav a:hover {
   color: var(--qwex-accent);
-  box-shadow: var(--qwex-shadow-glow);
-  transform: translateY(-2px);
+  background: rgba(125, 211, 252, 0.08);
+  transform: translateY(-1px);
 }
 
 /* Desktop nav emoji support via data attribute */
@@ -233,49 +248,60 @@ body {
 
 .qwex-hero h1 {
   font-size: var(--qwex-fs-xxl);
-  color: var(--qwex-accent);
-  text-shadow: var(--qwex-shadow-glow);
+  color: var(--qwex-fg);
+  font-family: var(--qwex-font-display);
+  letter-spacing: -0.02em;
 }
 
 .qwex-hero p {
   font-size: var(--qwex-fs-lg);
   color: var(--qwex-muted);
+  letter-spacing: 0.01em;
+}
+
+.qwex-title {
+  font-family: var(--qwex-font-display);
+  letter-spacing: -0.015em;
 }
 
 .qwex-card {
-  background: var(--qwex-card);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.02), rgba(0, 0, 0, 0.22)),
+    var(--qwex-card);
   border: 1px solid var(--qwex-border);
   border-radius: var(--qwex-radius-lg);
   box-shadow: var(--qwex-shadow-soft);
   padding: var(--qwex-space-md);
   width: 100%;
-  transition: transform 0.2s, box-shadow 0.2s;
+  transition: transform 0.2s, box-shadow 0.2s, border-color 0.2s;
 }
 
 .qwex-card:hover {
   box-shadow: var(--qwex-shadow-lift);
-  transform: translateY(-4px);
+  transform: translateY(-3px);
+  border-color: rgba(125, 211, 252, 0.35);
 }
 
 .qwex-btn {
   background: var(--qwex-accent);
-  color: #0f1419;
+  color: #0b1015;
   border: 1px solid var(--qwex-border);
   border-radius: var(--qwex-radius-sm);
   padding: var(--qwex-space-sm) var(--qwex-space-md);
+  font-weight: 600;
+  letter-spacing: 0.02em;
   transition: background 0.2s, box-shadow 0.2s, transform 0.2s;
 }
 
 .qwex-btn:hover {
   background: var(--qwex-accent-2);
-  color: #0f1419;
-  box-shadow: var(--qwex-shadow-glow);
+  color: #0b1015;
+  box-shadow: 0 0 16px rgba(167, 243, 208, 0.25);
   transform: translateY(-2px);
 }
 
 .qwex-link {
   color: var(--qwex-link);
-  transition: color 0.2s;
+  transition: color 0.2s, border-color 0.2s, background 0.2s;
 }
 
 .qwex-link:hover {
@@ -350,6 +376,12 @@ body {
   color: var(--qwex-accent-2);
 }
 
+.prose a:where(:not(.qwex-btn)) {
+  text-decoration: underline;
+  text-decoration-color: rgba(125, 211, 252, 0.4);
+  text-underline-offset: 3px;
+}
+
 .prose code {
   background: var(--qwex-border);
   color: var(--qwex-accent);
@@ -368,6 +400,12 @@ body {
   margin: 1rem 0;
 }
 
+.prose pre code {
+  background: transparent;
+  padding: 0;
+  color: inherit;
+}
+
 .prose blockquote {
   border-left: 4px solid var(--qwex-accent);
   padding-left: 1rem;
@@ -383,8 +421,54 @@ body {
   padding-left: 1.5rem;
 }
 
+.prose ul {
+  list-style: disc;
+}
+
+.prose ol {
+  list-style: decimal;
+}
+
 .prose li {
   margin: 0.5rem 0;
+}
+
+.prose li::marker {
+  color: var(--qwex-accent-2);
+}
+
+.prose hr {
+  border: 0;
+  border-top: 1px solid var(--qwex-border);
+  margin: 2rem 0;
+}
+
+.prose table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1.5rem 0;
+  font-size: 0.95em;
+}
+
+.prose th,
+.prose td {
+  border: 1px solid var(--qwex-border);
+  padding: 0.5rem 0.75rem;
+}
+
+.prose th {
+  background: rgba(125, 211, 252, 0.08);
+  color: var(--qwex-fg);
+  text-align: left;
+}
+
+.prose tr:nth-child(even) {
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.prose img {
+  border-radius: 12px;
+  border: 1px solid var(--qwex-border);
 }
 
 /* ===== MOBILE IMPROVEMENTS ===== */

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -1,33 +1,33 @@
 @import "tailwindcss";
-@import url("https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Work+Sans:wght@400;500;600&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&display=swap");
 
 :root {
-  --qwex-bg: #0c1116;
-  --qwex-fg: #e7edf4;
-  --qwex-muted: #9aa6b2;
-  --qwex-card: #141a21;
-  --qwex-border: #22303a;
-  --qwex-header-top: #0a0f14;
-  --qwex-header-bottom: #111821;
-  --qwex-header-a: rgba(125, 211, 252, 0.12);
-  --qwex-header-b: rgba(167, 243, 208, 0.12);
-  --qwex-accent: #7dd3fc;
-  --qwex-accent-2: #a7f3d0;
-  --qwex-link: #8ab4f8;
-  --qwex-shadow-soft: 0 10px 26px rgba(0, 0, 0, 0.28);
-  --qwex-shadow-lift: 0 16px 36px rgba(0, 0, 0, 0.38);
-  --qwex-shadow-glow: 0 0 16px rgba(125, 211, 252, 0.25);
-  --qwex-radius-lg: 20px;
-  --qwex-radius-sm: 12px;
-  --qwex-font-body: "Work Sans", ui-sans-serif, system-ui, -apple-system,
-    "Segoe UI", "Helvetica Neue", Arial;
-  --qwex-font-display: "Space Grotesk", "Work Sans", ui-sans-serif, system-ui,
-    -apple-system, "Segoe UI", "Helvetica Neue", Arial;
-  --qwex-fs-sm: 14px;
-  --qwex-fs-md: 16px;
-  --qwex-fs-lg: 18px;
-  --qwex-fs-xl: 26px;
-  --qwex-fs-xxl: 44px;
+  --qwex-bg: #0a0c0a;
+  --qwex-fg: #cfead2;
+  --qwex-muted: #7f9482;
+  --qwex-card: #0f1310;
+  --qwex-border: #1f2a22;
+  --qwex-header-top: #0b0f0b;
+  --qwex-header-bottom: #0f1410;
+  --qwex-header-a: rgba(94, 234, 122, 0.08);
+  --qwex-header-b: rgba(251, 191, 36, 0.08);
+  --qwex-accent: #5eea7a;
+  --qwex-accent-2: #fbbf24;
+  --qwex-link: #9bd69d;
+  --qwex-shadow-soft: 0 0 0 rgba(0, 0, 0, 0);
+  --qwex-shadow-lift: 0 0 0 rgba(0, 0, 0, 0);
+  --qwex-shadow-glow: 0 0 10px rgba(94, 234, 122, 0.25);
+  --qwex-radius-lg: 6px;
+  --qwex-radius-sm: 4px;
+  --qwex-font-body: "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo,
+    Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  --qwex-font-display: "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo,
+    Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  --qwex-fs-sm: 12px;
+  --qwex-fs-md: 14px;
+  --qwex-fs-lg: 16px;
+  --qwex-fs-xl: 20px;
+  --qwex-fs-xxl: 30px;
   --qwex-space-xs: 4px;
   --qwex-space-sm: 8px;
   --qwex-space-md: 16px;
@@ -38,11 +38,11 @@
 /* Mobile-first responsive font sizes */
 @media (max-width: 640px) {
   :root {
-    --qwex-fs-sm: 13px;
-    --qwex-fs-md: 15px;
-    --qwex-fs-lg: 16px;
-    --qwex-fs-xl: 22px;
-    --qwex-fs-xxl: 32px;
+    --qwex-fs-sm: 12px;
+    --qwex-fs-md: 13px;
+    --qwex-fs-lg: 15px;
+    --qwex-fs-xl: 18px;
+    --qwex-fs-xxl: 26px;
   }
 }
 
@@ -57,22 +57,34 @@ html {
 /* Base body styles */
 body {
   overflow-x: hidden;
-  background: radial-gradient(
-      1200px 800px at 12% -10%,
-      rgba(125, 211, 252, 0.14),
-      transparent 55%
-    ),
-    radial-gradient(
-      900px 650px at 88% 10%,
-      rgba(167, 243, 208, 0.12),
-      transparent 55%
-    ),
-    var(--qwex-bg);
-  background-attachment: fixed;
+  background: var(--qwex-bg);
   color: var(--qwex-fg);
   font-family: var(--qwex-font-body);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  position: relative;
+}
+
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background-image: repeating-linear-gradient(
+    to bottom,
+    rgba(255, 255, 255, 0.03),
+    rgba(255, 255, 255, 0.03) 1px,
+    transparent 1px,
+    transparent 3px
+  );
+  mix-blend-mode: screen;
+  opacity: 0.3;
+  z-index: 0;
+}
+
+body > * {
+  position: relative;
+  z-index: 1;
 }
 
 .qwex-nav {
@@ -81,31 +93,30 @@ body {
     var(--qwex-header-top),
     var(--qwex-header-bottom)
   );
-  box-shadow: 0 1px 0 var(--qwex-border), 0 12px 30px rgba(0, 0, 0, 0.25);
+  box-shadow: inset 0 -1px 0 var(--qwex-border);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
 }
 
 .qwex-nav ul {
-  gap: var(--qwex-space-md);
+  gap: var(--qwex-space-sm);
 }
 
 .qwex-nav a {
   color: var(--qwex-link);
-  padding: var(--qwex-space-sm) var(--qwex-space-md);
-  border-radius: var(--qwex-radius-sm);
+  padding: 6px 10px;
+  border-radius: 2px;
   font-weight: 500;
-  letter-spacing: 0.01em;
-  transition: background 0.2s, transform 0.2s, color 0.2s;
+  letter-spacing: 0.06em;
+  transition: background 0.2s, color 0.2s, box-shadow 0.2s;
+  border: 1px solid transparent;
 }
 
 .qwex-nav a:hover {
   color: var(--qwex-accent);
-  background: rgba(125, 211, 252, 0.08);
-  transform: translateY(-1px);
-}
-
-/* Desktop nav emoji support via data attribute */
-.qwex-nav ul:not(.mobile-menu) a[data-emoji]::before {
-  content: attr(data-emoji) " ";
+  background: rgba(94, 234, 122, 0.08);
+  border-color: rgba(94, 234, 122, 0.2);
+  box-shadow: 0 0 0 1px rgba(94, 234, 122, 0.2) inset;
 }
 
 /* Hamburger menu button */
@@ -164,14 +175,12 @@ body {
   left: 0;
   right: 0;
   bottom: 0;
-  background: rgba(0, 0, 0, 0.8);
-  backdrop-filter: blur(8px);
-  -webkit-backdrop-filter: blur(8px);
+  background: rgba(6, 8, 6, 0.96);
   opacity: 0;
   visibility: hidden;
-  transition: opacity 0.3s ease, visibility 0.3s ease;
+  transition: opacity 0.2s ease, visibility 0.2s ease;
   z-index: 40;
-  padding-top: 70px;
+  padding-top: 56px;
 }
 
 .mobile-menu-overlay.open {
@@ -185,11 +194,11 @@ body {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 0.5rem;
-  padding: 2rem;
-  transform: translateY(-20px);
+  gap: 0.35rem;
+  padding: 1.5rem 1rem;
+  transform: translateY(-10px);
   opacity: 0;
-  transition: transform 0.3s ease, opacity 0.3s ease;
+  transition: transform 0.2s ease, opacity 0.2s ease;
 }
 
 .mobile-menu.open {
@@ -223,15 +232,17 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 1rem 1.5rem;
+  padding: 0.75rem 1rem;
   color: var(--qwex-fg);
-  font-size: 1.125rem;
+  font-size: 0.95rem;
   font-weight: 500;
-  border-radius: var(--qwex-radius-sm);
+  border-radius: 2px;
   border: 1px solid var(--qwex-border);
   background: var(--qwex-card);
   transition: all 0.2s ease;
   text-decoration: none;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
 }
 
 .mobile-menu a:hover,
@@ -243,75 +254,99 @@ body {
 }
 
 .qwex-hero {
-  gap: var(--qwex-space-md);
+  gap: var(--qwex-space-sm);
 }
 
 .qwex-hero h1 {
   font-size: var(--qwex-fs-xxl);
   color: var(--qwex-fg);
   font-family: var(--qwex-font-display);
-  letter-spacing: -0.02em;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
 }
 
 .qwex-hero p {
-  font-size: var(--qwex-fs-lg);
+  font-size: var(--qwex-fs-md);
   color: var(--qwex-muted);
-  letter-spacing: 0.01em;
+  letter-spacing: 0.02em;
 }
 
 .qwex-title {
   font-family: var(--qwex-font-display);
-  letter-spacing: -0.015em;
+  letter-spacing: 0.04em;
+  position: relative;
+}
+
+.qwex-title::before {
+  content: "> ";
+  color: var(--qwex-accent);
+}
+
+.terminal-cursor::after {
+  content: "█";
+  margin-left: 6px;
+  color: var(--qwex-accent-2);
+  animation: blink 1s steps(2, start) infinite;
+}
+
+@keyframes blink {
+  50% {
+    opacity: 0;
+  }
 }
 
 .qwex-card {
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.02), rgba(0, 0, 0, 0.22)),
-    var(--qwex-card);
+  background: var(--qwex-card);
   border: 1px solid var(--qwex-border);
   border-radius: var(--qwex-radius-lg);
-  box-shadow: var(--qwex-shadow-soft);
-  padding: var(--qwex-space-md);
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.25);
+  padding: var(--qwex-space-sm) var(--qwex-space-md);
   width: 100%;
-  transition: transform 0.2s, box-shadow 0.2s, border-color 0.2s;
+  transition: border-color 0.2s, box-shadow 0.2s;
+  position: relative;
+  z-index: 1;
 }
 
 .qwex-card:hover {
-  box-shadow: var(--qwex-shadow-lift);
-  transform: translateY(-3px);
-  border-color: rgba(125, 211, 252, 0.35);
+  box-shadow: 0 0 0 1px rgba(94, 234, 122, 0.3);
+  border-color: rgba(94, 234, 122, 0.45);
 }
 
 .qwex-btn {
-  background: var(--qwex-accent);
-  color: #0b1015;
-  border: 1px solid var(--qwex-border);
+  background: transparent;
+  color: var(--qwex-accent);
+  border: 1px solid var(--qwex-accent);
   border-radius: var(--qwex-radius-sm);
-  padding: var(--qwex-space-sm) var(--qwex-space-md);
+  padding: 6px 10px;
   font-weight: 600;
-  letter-spacing: 0.02em;
-  transition: background 0.2s, box-shadow 0.2s, transform 0.2s;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  transition: background 0.2s, box-shadow 0.2s, color 0.2s;
 }
 
 .qwex-btn:hover {
-  background: var(--qwex-accent-2);
-  color: #0b1015;
-  box-shadow: 0 0 16px rgba(167, 243, 208, 0.25);
-  transform: translateY(-2px);
+  background: rgba(94, 234, 122, 0.12);
+  color: var(--qwex-accent);
+  box-shadow: var(--qwex-shadow-glow);
 }
 
 .qwex-link {
   color: var(--qwex-link);
   transition: color 0.2s, border-color 0.2s, background 0.2s;
+  text-decoration: underline;
+  text-decoration-style: dotted;
+  text-underline-offset: 3px;
 }
 
 .qwex-link:hover {
   color: var(--qwex-accent-2);
+  background: rgba(251, 191, 36, 0.08);
 }
 
 @keyframes fade-in-up {
   from {
     opacity: 0;
-    transform: translateY(1rem);
+    transform: translateY(0.35rem);
   }
   to {
     opacity: 1;
@@ -329,7 +364,7 @@ body {
 }
 
 .animate-fade-in-up {
-  animation: fade-in-up 0.5s ease-out forwards;
+  animation: fade-in-up 0.25s ease-out forwards;
 }
 
 .animate-fade-out {
@@ -337,33 +372,39 @@ body {
 }
 
 /* Blog post styling */
-.prose h1 {
-  color: var(--qwex-accent);
-  font-size: 2rem;
-  font-weight: bold;
-  margin-bottom: 1rem;
-}
+  .prose h1 {
+    color: var(--qwex-accent);
+    font-size: 1.6rem;
+    font-weight: 600;
+    margin-bottom: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+  }
 
 .prose h2 {
   color: var(--qwex-accent-2);
-  font-size: 1.5rem;
+  font-size: 1.2rem;
   font-weight: 600;
-  margin-top: 2rem;
-  margin-bottom: 1rem;
+  margin-top: 1.25rem;
+  margin-bottom: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
 }
 
 .prose h3 {
   color: var(--qwex-fg);
-  font-size: 1.25rem;
-  font-weight: 500;
-  margin-top: 1.5rem;
-  margin-bottom: 0.75rem;
+  font-size: 1rem;
+  font-weight: 600;
+  margin-top: 1rem;
+  margin-bottom: 0.5rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
 }
 
 .prose p {
   color: var(--qwex-fg);
-  line-height: 1.7;
-  margin-bottom: 1rem;
+  line-height: 1.6;
+  margin-bottom: 0.75rem;
 }
 
 .prose a {
@@ -378,26 +419,25 @@ body {
 
 .prose a:where(:not(.qwex-btn)) {
   text-decoration: underline;
-  text-decoration-color: rgba(125, 211, 252, 0.4);
+  text-decoration-color: rgba(94, 234, 122, 0.4);
   text-underline-offset: 3px;
 }
 
 .prose code {
-  background: var(--qwex-border);
+  background: #0b100c;
   color: var(--qwex-accent);
-  padding: 0.2rem 0.4rem;
-  border-radius: 4px;
-  font-family: "SF Mono", Monaco, "Cascadia Code", "Roboto Mono", Consolas,
-    "Courier New", monospace;
+  padding: 0.2rem 0.35rem;
+  border-radius: 3px;
+  font-family: var(--qwex-font-body);
 }
 
 .prose pre {
-  background: var(--qwex-border);
+  background: #0b100c;
   color: var(--qwex-fg);
-  padding: 1rem;
-  border-radius: 8px;
+  padding: 0.75rem;
+  border-radius: 4px;
   overflow-x: auto;
-  margin: 1rem 0;
+  margin: 0.75rem 0;
 }
 
 .prose pre code {
@@ -407,18 +447,18 @@ body {
 }
 
 .prose blockquote {
-  border-left: 4px solid var(--qwex-accent);
-  padding-left: 1rem;
+  border-left: 2px solid var(--qwex-accent);
+  padding-left: 0.75rem;
   color: var(--qwex-muted);
   font-style: italic;
-  margin: 1rem 0;
+  margin: 0.75rem 0;
 }
 
 .prose ul,
 .prose ol {
   color: var(--qwex-fg);
-  margin: 1rem 0;
-  padding-left: 1.5rem;
+  margin: 0.75rem 0;
+  padding-left: 1.25rem;
 }
 
 .prose ul {
@@ -430,7 +470,7 @@ body {
 }
 
 .prose li {
-  margin: 0.5rem 0;
+  margin: 0.35rem 0;
 }
 
 .prose li::marker {
@@ -440,30 +480,30 @@ body {
 .prose hr {
   border: 0;
   border-top: 1px solid var(--qwex-border);
-  margin: 2rem 0;
+  margin: 1.25rem 0;
 }
 
 .prose table {
   width: 100%;
   border-collapse: collapse;
-  margin: 1.5rem 0;
-  font-size: 0.95em;
+  margin: 1rem 0;
+  font-size: 0.9em;
 }
 
 .prose th,
 .prose td {
   border: 1px solid var(--qwex-border);
-  padding: 0.5rem 0.75rem;
+  padding: 0.4rem 0.6rem;
 }
 
 .prose th {
-  background: rgba(125, 211, 252, 0.08);
+  background: rgba(94, 234, 122, 0.08);
   color: var(--qwex-fg);
   text-align: left;
 }
 
 .prose tr:nth-child(even) {
-  background: rgba(255, 255, 255, 0.02);
+  background: rgba(255, 255, 255, 0.015);
 }
 
 .prose img {

--- a/app/src/pages/About.jsx
+++ b/app/src/pages/About.jsx
@@ -5,9 +5,7 @@ export default function About({ id }) {
   return (
     <Section id={id}>
       <SectionHeader
-        emoji="👤"
         title="About"
-        subtitle="The human behind the code"
       />
 
       <Card className="max-w-2xl mx-4 sm:mx-0">
@@ -15,17 +13,17 @@ export default function About({ id }) {
           <img
             src="/headshot.JPG"
             alt="Profile"
-            className="rounded-full w-24 h-24 sm:w-32 sm:h-32 object-cover mx-auto border-2 border-[var(--qwex-border)] group-hover:border-[var(--qwex-accent)] transition-colors duration-300"
+            className="rounded-sm w-20 h-20 sm:w-24 sm:h-24 object-cover mx-auto border border-[var(--qwex-border)] group-hover:border-[var(--qwex-accent)] transition-colors duration-300"
           />
         </div>
 
-        <p className="text-[var(--qwex-muted)] leading-relaxed mb-4 text-sm sm:text-base">
-          fullstack software engineer with expertise in backend systems. if
-          i'm not hacking on a new project, you can find me in the garden, or
-          at the board game table
+        <p className="text-[var(--qwex-muted)] leading-relaxed mb-3 text-xs sm:text-sm">
+          Fullstack software engineer with a backend focus. New father, builder,
+          and lifelong tinkerer—when I'm not coding, you'll find me in the
+          garden or at the board game table.
         </p>
 
-        <div className="text-xs sm:text-sm text-[var(--qwex-accent-2)] opacity-80">
+        <div className="text-xs text-[var(--qwex-accent-2)] opacity-80">
           coding • gardening • board games
         </div>
       </Card>

--- a/app/src/pages/Blog.jsx
+++ b/app/src/pages/Blog.jsx
@@ -92,7 +92,6 @@ export default function Blog({ id }) {
   return (
     <Section id={id}>
       <SectionHeader
-        emoji="📚"
         title="Blog"
         subtitle="Thoughts and insights"
       />
@@ -102,7 +101,7 @@ export default function Blog({ id }) {
           {postEntries.map(([path, post], index) => (
             <li key={path}>
               <button
-                className={`qwex-btn group-hover:shadow-[var(--qwex-shadow-glow)] transition-all duration-200 inline-flex items-center gap-2 text-sm sm:text-base min-h-[44px] px-4 py-2 active:scale-95 ${
+                className={`qwex-btn group-hover:shadow-[var(--qwex-shadow-glow)] transition-all duration-200 inline-flex items-center gap-2 text-xs sm:text-sm min-h-[44px] px-3 py-2 active:scale-95 ${
                   activePost === path
                     ? "bg-[var(--qwex-accent-2)] text-[#0f1419]"
                     : ""
@@ -111,23 +110,20 @@ export default function Blog({ id }) {
                 disabled={isClosing}
                 style={{ animationDelay: `${index * 100}ms` }}
               >
-                <span className="text-xs">
-                  {activePost === path ? "📖" : "📄"}
-                </span>
-                <span className="truncate">{path.split("/").pop()}</span>
-                {activePost === path && (
-                  <span className="text-xs ml-1">✕</span>
-                )}
-              </button>
+                  <span className="truncate">{path.split("/").pop()}</span>
+                  {activePost === path && (
+                    <span className="text-xs ml-1">[close]</span>
+                  )}
+                </button>
             </li>
           ))}
         </ul>
       </Card>
 
       {content && (
-        <article
+         <article
           ref={articleRef}
-          className="qwex-card mt-2 sm:mt-4 text-left opacity-0 max-w-4xl w-full mx-4 sm:mx-0 relative p-4 sm:p-6"
+          className="qwex-card mt-2 sm:mt-3 text-left opacity-0 max-w-4xl w-full mx-4 sm:mx-0 relative p-3 sm:p-4"
         >
           <button
             onClick={closePost}
@@ -152,7 +148,7 @@ export default function Blog({ id }) {
             </svg>
           </button>
 
-          <div className="prose prose-invert max-w-none pr-10 sm:pr-12 text-sm sm:text-base">
+          <div className="prose prose-invert max-w-none pr-10 sm:pr-12 text-xs sm:text-sm">
             <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>
           </div>
         </article>

--- a/app/src/pages/Blog.jsx
+++ b/app/src/pages/Blog.jsx
@@ -1,15 +1,21 @@
 import { useState, useEffect, useRef } from "react";
 import PropTypes from "prop-types";
 import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
 import { Card, Section, SectionHeader } from "../components";
 
-const posts = import.meta.glob("../posts/*.md", { query: "raw" });
+const posts = import.meta.glob("../posts/*.md", {
+  query: "?raw",
+  import: "default",
+  eager: true,
+});
 
 export default function Blog({ id }) {
   const [content, setContent] = useState("");
   const [activePost, setActivePost] = useState("");
   const [isClosing, setIsClosing] = useState(false);
   const articleRef = useRef(null);
+  const postEntries = Object.entries(posts);
 
   const closePostAnimated = () => {
     return new Promise((resolve) => {
@@ -32,7 +38,20 @@ export default function Blog({ id }) {
     });
   };
 
-  const loadPost = async (path) => {
+  const resolvePostContent = async (post) => {
+    if (typeof post === "string") {
+      return post;
+    }
+
+    if (typeof post === "function") {
+      const result = await post();
+      return typeof result === "string" ? result : result?.default;
+    }
+
+    return post?.default;
+  };
+
+  const loadPost = async (path, post) => {
     try {
       if (activePost === path) {
         closePostAnimated();
@@ -43,8 +62,8 @@ export default function Blog({ id }) {
         await closePostAnimated();
       }
 
-      const md = await posts[path]();
-      setContent(md.default || md);
+      const markdown = await resolvePostContent(post);
+      setContent(markdown || "");
       setActivePost(path);
     } catch {
       setContent("Error loading post content.");
@@ -80,7 +99,7 @@ export default function Blog({ id }) {
 
       <Card className="max-w-2xl w-full mx-4 sm:mx-0">
         <ul className="flex flex-col gap-2 sm:gap-3">
-          {Object.keys(posts).map((path, index) => (
+          {postEntries.map(([path, post], index) => (
             <li key={path}>
               <button
                 className={`qwex-btn group-hover:shadow-[var(--qwex-shadow-glow)] transition-all duration-200 inline-flex items-center gap-2 text-sm sm:text-base min-h-[44px] px-4 py-2 active:scale-95 ${
@@ -88,7 +107,7 @@ export default function Blog({ id }) {
                     ? "bg-[var(--qwex-accent-2)] text-[#0f1419]"
                     : ""
                 } ${isClosing ? "opacity-50 cursor-not-allowed" : ""}`}
-                onClick={() => !isClosing && loadPost(path)}
+                onClick={() => !isClosing && loadPost(path, post)}
                 disabled={isClosing}
                 style={{ animationDelay: `${index * 100}ms` }}
               >
@@ -134,7 +153,7 @@ export default function Blog({ id }) {
           </button>
 
           <div className="prose prose-invert max-w-none pr-10 sm:pr-12 text-sm sm:text-base">
-            <ReactMarkdown>{content}</ReactMarkdown>
+            <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>
           </div>
         </article>
       )}

--- a/app/src/pages/Contact.jsx
+++ b/app/src/pages/Contact.jsx
@@ -5,15 +5,14 @@ export default function Contact({ id }) {
   return (
     <Section id={id}>
       <SectionHeader
-        emoji="✉️"
         title="Contact"
         subtitle="Let's connect and build something amazing"
       />
 
-      <Card className="max-w-lg w-full mx-4 sm:mx-0" contentClassName="p-4 sm:p-6 md:p-8 space-y-3 sm:space-y-4">
+      <Card className="max-w-lg w-full mx-4 sm:mx-0" contentClassName="p-3 sm:p-4 md:p-5 space-y-2 sm:space-y-3">
         <p className="group/item">
           <a
-            className="qwex-link inline-flex items-center justify-center sm:justify-start gap-3 p-3 sm:p-4 min-h-[48px] w-full rounded-lg border border-[var(--qwex-border)] hover:border-[var(--qwex-accent)] transition-all duration-200 group-hover/item:bg-[var(--qwex-accent)] group-hover/item:bg-opacity-5 active:scale-[0.98] text-sm sm:text-base"
+            className="qwex-link inline-flex items-center justify-center sm:justify-start gap-3 p-3 sm:p-4 min-h-[48px] w-full rounded-md border border-[var(--qwex-border)] hover:border-[var(--qwex-accent)] transition-all duration-200 group-hover/item:bg-[var(--qwex-accent)] group-hover/item:bg-opacity-5 active:scale-[0.98] text-xs sm:text-sm"
             href="mailto:bjc9001@gmail.com"
           >
             <MailIcon className="w-5 h-5 flex-shrink-0" />
@@ -23,7 +22,7 @@ export default function Contact({ id }) {
 
         <p className="group/item">
           <a
-            className="qwex-link inline-flex items-center justify-center sm:justify-start gap-3 p-3 sm:p-4 min-h-[48px] w-full rounded-lg border border-[var(--qwex-border)] hover:border-[var(--qwex-accent-2)] transition-all duration-200 group-hover/item:bg-[var(--qwex-accent-2)] group-hover/item:bg-opacity-5 active:scale-[0.98] text-sm sm:text-base"
+            className="qwex-link inline-flex items-center justify-center sm:justify-start gap-3 p-3 sm:p-4 min-h-[48px] w-full rounded-md border border-[var(--qwex-border)] hover:border-[var(--qwex-accent-2)] transition-all duration-200 group-hover/item:bg-[var(--qwex-accent-2)] group-hover/item:bg-opacity-5 active:scale-[0.98] text-xs sm:text-sm"
             href="https://www.linkedin.com/in/bchurchill23/"
             target="_blank"
             rel="noopener noreferrer"
@@ -36,13 +35,12 @@ export default function Contact({ id }) {
 
         <p className="group/item">
           <a
-            className="qwex-btn inline-flex items-center justify-center gap-3 min-h-[48px] w-full sm:w-auto px-6 py-3 group-hover:shadow-[var(--qwex-shadow-glow)] transition-all duration-200 active:scale-[0.98] text-sm sm:text-base"
+            className="qwex-btn inline-flex items-center justify-center gap-3 min-h-[48px] w-full sm:w-auto px-5 py-3 group-hover:shadow-[var(--qwex-shadow-glow)] transition-all duration-200 active:scale-[0.98] text-xs sm:text-sm"
             href="/resume.pdf"
             target="_blank"
             rel="noopener noreferrer"
             aria-label="Download Resume PDF (opens in new tab)"
           >
-            <span className="text-sm">📄</span>
             Resume (PDF)
           </a>
         </p>

--- a/app/src/pages/Intro.jsx
+++ b/app/src/pages/Intro.jsx
@@ -6,7 +6,7 @@ export default function Intro({ id }) {
       id={id}
       className="min-h-screen flex flex-col items-center justify-center qwex-hero px-4 py-12 sm:p-8 text-center animate-fade-in-up"
     >
-      <h1 className="font-bold text-2xl sm:text-3xl md:text-4xl lg:text-[var(--qwex-fs-xxl)] leading-tight">
+      <h1 className="qwex-title font-semibold text-2xl sm:text-3xl md:text-4xl lg:text-[var(--qwex-fs-xxl)] leading-tight">
         I am Benjamin Churchill
       </h1>
       <p className="max-w-prose text-[var(--qwex-muted)] text-sm sm:text-base md:text-lg mt-4">

--- a/app/src/pages/Intro.jsx
+++ b/app/src/pages/Intro.jsx
@@ -4,12 +4,12 @@ export default function Intro({ id }) {
   return (
     <section
       id={id}
-      className="min-h-screen flex flex-col items-center justify-center qwex-hero px-4 py-12 sm:p-8 text-center animate-fade-in-up"
+      className="flex flex-col items-center justify-start qwex-hero px-4 py-8 sm:py-10 text-center animate-fade-in-up"
     >
-      <h1 className="qwex-title font-semibold text-2xl sm:text-3xl md:text-4xl lg:text-[var(--qwex-fs-xxl)] leading-tight">
+      <h1 className="qwex-title terminal-cursor font-semibold text-xl sm:text-2xl md:text-3xl lg:text-[var(--qwex-fs-xxl)] leading-tight">
         I am Benjamin Churchill
       </h1>
-      <p className="max-w-prose text-[var(--qwex-muted)] text-sm sm:text-base md:text-lg mt-4">
+      <p className="max-w-prose text-[var(--qwex-muted)] text-xs sm:text-sm md:text-base mt-2">
         Software Engineer | Full-stack Developer | Problem Solver
       </p>
     </section>

--- a/app/src/pages/Projects.jsx
+++ b/app/src/pages/Projects.jsx
@@ -19,6 +19,19 @@ const projects = [
     github: "https://github.com/qWeX23/chicken-api",
   },
   {
+    id: "music-link-swap",
+    title: "Music Link Swap",
+    emoji: "🎵🔗",
+    description: "Convert music links between streaming services.",
+    website: "https://music-link-swap.qwex.co/",
+  },
+  {
+    id: "tanks",
+    title: "Tanks",
+    description: "real time llm tank showdown",
+    website: "https://tanks.qwex.co/",
+  },
+  {
     id: "secret-ca",
     title: "Secret Project CA",
     description: "-",

--- a/app/src/pages/Projects.jsx
+++ b/app/src/pages/Projects.jsx
@@ -13,7 +13,6 @@ const projects = [
   {
     id: "chicken-api",
     title: "The Chicken API",
-    emoji: "🐔🌐",
     description: "The open source API for all things chicken.",
     website: "https://chickenapi.com",
     github: "https://github.com/qWeX23/chicken-api",
@@ -47,12 +46,11 @@ export default function Projects({ id }) {
   return (
     <Section id={id}>
       <SectionHeader
-        emoji="🛠️"
         title="Projects"
         subtitle="Building cool stuff, one repo at a time"
       />
 
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-4 sm:gap-6 md:gap-8 max-w-5xl w-full justify-items-center">
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-3 sm:gap-4 md:gap-5 max-w-5xl w-full justify-items-center">
         {projects.map((proj, index) => (
           <Card
             key={proj.id}
@@ -60,11 +58,10 @@ export default function Projects({ id }) {
             contentClassName="p-1 sm:p-2"
             style={{ animationDelay: `${index * 100}ms` }}
           >
-            <h2 className="text-lg sm:text-xl font-semibold mb-2 sm:mb-3 group-hover:text-[var(--qwex-accent)] transition-colors duration-200">
-              {proj.title}
-              {proj.emoji && <span className="ml-2">{proj.emoji}</span>}
-            </h2>
-            <p className="text-[var(--qwex-muted)] mb-4 sm:mb-6 min-h-[2.5rem] sm:min-h-[3rem] flex items-center justify-center text-sm sm:text-base">
+              <h2 className="text-base sm:text-lg font-semibold mb-2 group-hover:text-[var(--qwex-accent)] transition-colors duration-200">
+                {proj.title}
+              </h2>
+            <p className="text-[var(--qwex-muted)] mb-3 sm:mb-4 min-h-[2rem] sm:min-h-[2.5rem] flex items-center justify-center text-xs sm:text-sm">
               {proj.description === "-" ? (
                 <span className="text-xs sm:text-sm opacity-60">[ CLASSIFIED ]</span>
               ) : (
@@ -82,7 +79,6 @@ export default function Projects({ id }) {
                   aria-label={`Visit ${proj.title} website (opens in new tab)`}
                   className="qwex-btn inline-flex items-center gap-2 text-xs sm:text-sm px-3 py-2 min-h-[44px] group-hover:shadow-[var(--qwex-shadow-glow)] transition-all duration-200"
                 >
-                  <span className="text-xs">🚀</span>
                   VISIT
                 </a>
               )}
@@ -94,7 +90,6 @@ export default function Projects({ id }) {
                   aria-label={`View ${proj.title} source code on GitHub (opens in new tab)`}
                   className="qwex-link inline-flex items-center gap-2 px-3 py-2 text-xs sm:text-sm min-h-[44px] border border-[var(--qwex-border)] rounded-lg hover:border-[var(--qwex-accent-2)] hover:bg-[var(--qwex-accent-2)] hover:bg-opacity-10 transition-all duration-200 active:scale-95"
                 >
-                  <span className="text-xs">⚡</span>
                   SOURCE
                 </a>
               )}

--- a/opencode.json
+++ b/opencode.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "playwright": {
+      "type": "local",
+      "command": ["npx", "@playwright/mcp@latest"],
+      "enabled": true
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- switch to a monospace terminal-style visual theme with green/amber palette
- tighten layout spacing and typography for a compact, dense layout
- remove emoji usage across navigation, section headers, and project cards
- update About copy with a new-father note

## Testing
- not run (not requested)